### PR TITLE
spec: don't build xwayland

### DIFF
--- a/mutter.spec
+++ b/mutter.spec
@@ -153,7 +153,7 @@ the functionality of the installed %{name} package.
 %autosetup -S git -n %{name}-%{tarball_version}
 
 %build
-%meson -Degl_device=true -Dwayland_eglstream=true
+%meson -Degl_device=true -Dwayland_eglstream=true  -Dxwayland=false
 %meson_build
 
 %install


### PR DESCRIPTION
This is for a testing copr that provides Mutter without Xwayland support.

Note: Yes i know, xwayland is complete necessary for legacy X11 apps.